### PR TITLE
Added support for copying comments from the source to the compiled code

### DIFF
--- a/src/escodegen.js
+++ b/src/escodegen.js
@@ -1271,7 +1271,15 @@
         VariableDeclaration: ['declarations'],
         VariableDeclarator: ['id', 'init'],
         WhileStatement: ['test', 'body'],
-        WithStatement: ['object', 'body']
+        WithStatement: ['object', 'body'],
+
+        PointerType: [],
+        StructType: [],
+        ArrowType: [],
+        TypeIdentifier: [],
+        FieldDeclarator: [],
+        TypeAliasDirective: [],
+        CastExpression: []
     };
 
     VisitorOption = {

--- a/src/esprima.js
+++ b/src/esprima.js
@@ -2295,6 +2295,7 @@
 
     return {
       type: Syntax.TypeAliasDirective,
+      range: original.range,
       original: original,
       alias: alias
     };
@@ -3047,6 +3048,7 @@
     if (type.id) {
       return {
         type: Syntax.TypeAliasDirective,
+        range: type.range,
         original: type,
         alias: {
           type: Syntax.TypeIdentifier,
@@ -3763,6 +3765,11 @@
       parseUnaryExpression = extra.parseUnaryExpression;
       parseVariableDeclaration = extra.parseVariableDeclaration;
       parseVariableIdentifier = extra.parseVariableIdentifier;
+
+      parsePointerType = extra.parsePointerType;
+      parseStructType = extra.parseStructType;
+      parseTypeIdentifier = extra.parseTypeIdentifier;
+      parseTypeDef = extra.parseTypeDef;
     }
 
     if (typeof extra.scanRegExp === 'function') {

--- a/src/estransform.js
+++ b/src/estransform.js
@@ -295,7 +295,7 @@
 
   function allFields(spec) {
     // Make the location a special last field.
-    var fields = ["loc"];
+    var fields = ["leadingComments", "loc"];
     while (spec) {
       if (spec.fields) {
         fields = spec.fields.concat(fields);

--- a/src/ljc.js
+++ b/src/ljc.js
@@ -174,7 +174,10 @@
     var code;
 
     try {
-      var node = esprima.parse(source, { loc: true });
+      var node = esprima.parse(source, { loc: true, comment: true, range: true, tokens: true });
+
+      node = escodegen.attachComments(node, node.comments, node.tokens);
+
       if (options["only-parse"]) {
         code = node;
       } else {
@@ -182,7 +185,7 @@
         if (options["emit-ast"]) {
           code = node;
         } else {
-          code = escodegen.generate(node, { base: "", indent: "  " });
+          code = escodegen.generate(node, { base: "", indent: "  ", comment: true });
         }
       }
     } catch (e) {


### PR DESCRIPTION
This pull request implements support for automatically copying comments from the `*.ljs` files to the `*.js` files. I needed this support to be able to run the generated code through Closure Compiler.
