### PR TITLE
Add more tests to cover float, double and num data types

### DIFF
--- a/test/types.ljs
+++ b/test/types.ljs
@@ -85,7 +85,7 @@ describe('Machine Types', function() {
   });
 
   it('num', function () {
-    let num x;     assert (x === 0);
+    let num x;        assert (x === 0);
     x = 1;            assert (x === 1);
     x = -1;           assert (x === -1);
     x = 0xffffffff;   assert (x === 4294967295);

--- a/test/types.ljs
+++ b/test/types.ljs
@@ -9,6 +9,7 @@ describe('Machine Types', function() {
     x = -1;           assert (x === 0xff);
     x = 0xff;         assert (x === 0xff);
     x += 1;           assert (x === 0);
+    x = 1.1;          assert (x/2 === 0);
                       assert (sizeof(u8) === 1);
   });
 
@@ -18,6 +19,7 @@ describe('Machine Types', function() {
     x = -1;           assert (x === -1);
     x = 0xff;         assert (x === -1);
     x += 1;           assert (x === 0);
+    x = 1.1;          assert (x/2 === 0);
                       assert (sizeof(i8) === 1);
   });
 
@@ -28,6 +30,7 @@ describe('Machine Types', function() {
     x = -1;           assert (x === 0xffff);
     x = 0xffff;       assert (x === 0xffff);
     x += 1;           assert (x === 0);
+    x = 1.1;          assert (x/2 === 0);
                       assert (sizeof(u16) === 2);
   });
 
@@ -37,6 +40,7 @@ describe('Machine Types', function() {
     x = -1;           assert (x === -1);
     x = 0xffff;       assert (x === -1);
     x += 1;           assert (x === 0);
+    x = 1.1;          assert (x/2 === 0);
                       assert (sizeof(i16) === 2);
   });
 
@@ -46,6 +50,7 @@ describe('Machine Types', function() {
     x = -1;           assert (x === 0xffffffff);
     x = 0xffffffff;   assert (x === 0xffffffff);
     x += 1;           assert (x === 0);
+    x = 1.1;          assert (x/2 === 0);
                       assert (sizeof(u32) === 4);
   });
 
@@ -55,15 +60,17 @@ describe('Machine Types', function() {
     x = -1;           assert (x === -1);
     x = 0xffffffff;   assert (x === -1);
     x += 1;           assert (x === 0);
+    x = 1.1;          assert (x/2 === 0);
                       assert (sizeof(i32) === 4);
   });
-  
+
   it('float', function () {
     let float x;      assert (x === 0);
     x = 1;            assert (x === 1);
     x = -1;           assert (x === -1);
     x = 0xffffffff;   assert (x === 4294967295);
     x += 1;           assert (x === 4294967296);
+    x = 1.1;          assert (x/2 === 0.55);
                       assert (sizeof(float) === 4);
   });
 
@@ -73,7 +80,18 @@ describe('Machine Types', function() {
     x = -1;           assert (x === -1);
     x = 0xffffffff;   assert (x === 4294967295);
     x += 1;           assert (x === 4294967296);
+    x = 1.1;          assert (x/2 === 0.55);
                       assert (sizeof(double) === 8);
+  });
+
+  it('num', function () {
+    let num x;     assert (x === 0);
+    x = 1;            assert (x === 1);
+    x = -1;           assert (x === -1);
+    x = 0xffffffff;   assert (x === 4294967295);
+    x += 1;           assert (x === 4294967296);
+    x = 1.1;          assert (x/2 === 0.55);
+                      assert (sizeof(num) === 8);
   });
 
 });

--- a/test/types.ljs
+++ b/test/types.ljs
@@ -57,5 +57,23 @@ describe('Machine Types', function() {
     x += 1;           assert (x === 0);
                       assert (sizeof(i32) === 4);
   });
+  
+  it('float', function () {
+    let float x;      assert (x === 0);
+    x = 1;            assert (x === 1);
+    x = -1;           assert (x === -1);
+    x = 0xffffffff;   assert (x === 4294967295);
+    x += 1;           assert (x === 4294967296);
+                      assert (sizeof(float) === 4);
+  });
+
+  it('double', function () {
+    let double x;     assert (x === 0);
+    x = 1;            assert (x === 1);
+    x = -1;           assert (x === -1);
+    x = 0xffffffff;   assert (x === 4294967295);
+    x += 1;           assert (x === 4294967296);
+                      assert (sizeof(double) === 8);
+  });
 
 });


### PR DESCRIPTION
Just a quick addition to the type tests to cover float, double and num data types. I've also added a test for division to cover some basic type coercion although that might want to be fleshed out further.