### PR TITLE
Heap allocated array example updated and uses delete

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -223,6 +223,7 @@ for (let int i=1; i <= 10; i++) {
 for (let int i=1; i <= 10; i++) {
   trace(i + ": " + heapArr[i-1]);
 }
+delete heapArr;
 
 // Stack allocated array inside a struct
 struct ArrayStruct {


### PR DESCRIPTION
I made the heap-allocated array example a little more realistic and included use of "delete".
