### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-lljs.org


### PR DESCRIPTION
This removes the automatic GitHub redirection from http://mbebenita.github.io/LLJS/ to the old domain name lljs.org that is not available anymore. This should at least make the LLJS docs viewable online.

Related issues:
* #40 
* #38